### PR TITLE
Fix hanging background processes on Sierra

### DIFF
--- a/src/workflow/background.py
+++ b/src/workflow/background.py
@@ -118,7 +118,7 @@ def _background(stdin='/dev/null', stdout='/dev/null',
     try:
         pid = os.fork()
         if pid > 0:
-            sys.exit(0)  # Exit first parent.
+            os._exit(0)  # Exit first parent.
     except OSError as e:
         wf().logger.critical("fork #1 failed: ({0:d}) {1}".format(
                              e.errno, e.strerror))
@@ -131,7 +131,7 @@ def _background(stdin='/dev/null', stdout='/dev/null',
     try:
         pid = os.fork()
         if pid > 0:
-            sys.exit(0)  # Exit second parent.
+            os._exit(0)  # Exit second parent.
     except OSError as e:
         wf().logger.critical("fork #2 failed: ({0:d}) {1}".format(
                              e.errno, e.strerror))


### PR DESCRIPTION
@azai91 First, thanks for your workflow.  It's the workflow I use the most.

This pull request fixes the Python process from using 100% CPU for macOS 10.12.4.

As the people in issue https://github.com/azai91/alfred-drive-workflow/issues/21 mentioned, the workflow sometime causes Python to use up 100% CPU.  The good folks over at https://github.com/deanishe/alfred-workflow/issues/111 looked into this issue and found the fix to replace `sys.exit(0)` to `os._exit(0)` in the background code.  Doing this worked seems to work for me, tested on macOS 10.12.4 + Alfred v3.3.1.

Considering the workflow hasn't been updated in almost a year, I figured I'll just update the errant code than update the library.

Thoughts?