### PR TITLE
Rename “Create Google «document»” actions to “New «document type»”

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ Responses from Google Drive API are cached to increase the speed. Use this optio
 - ```d > set cache [seconds]```
 Sets the length of the duration for how long responses are held in cache before a fresh request is made. Default is 3600 seconds (1 hour)
 
-- ```d > Create Google Doc```
+- ```d > New Document```
 Create Google Doc and opens in default browser
 
-- ```d > Create Google Sheet```
+- ```d > New Spreadsheet```
 Create Google Sheet and opens in default browser
 
-- ```d > Create Google Slide```
+- ```d > New Presentation```
 Create Google Slide and opens in default browser
 
-- ```d > Create Google Form```
+- ```d > New Form```
 Create Google Form and opens in default browser
 
 ##Supported files types

--- a/src/config.py
+++ b/src/config.py
@@ -51,26 +51,26 @@ SETTINGS = {
 
 CREATE_SETTINGS = {
     'DOC' : {
-        'title' : 'Create Google Doc',
-        'autocomplete' : '> Create Google Doc',
+        'title' : 'New Document',
+        'autocomplete' : '> New Document',
         'arg' : 'create_doc',
         'icon' : './icons/doc.png'
     },
     'SHEET' : {
-        'title' : 'Create Google Sheet',
-        'autocomplete' : '> Create Google Sheet',
+        'title' : 'New Spreadsheet',
+        'autocomplete' : '> New Spreadsheet',
         'arg' : 'create_sheet',
         'icon' : './icons/sheet.png'
     },
     'SLIDE' : {
-        'title' : 'Create Google Slide',
-        'autocomplete' : '> Create Google Slide',
+        'title' : 'New Presentation',
+        'autocomplete' : '> New Presentation',
         'arg' : 'create_slide',
         'icon' : './icons/slide.png'
     },
     'FORM' : {
-        'title' : 'Create Google Form',
-        'autocomplete' : '> Create Google Form',
+        'title' : 'New Form',
+        'autocomplete' : '> New Form',
         'arg' : 'create_form',
         'icon' : './icons/form.png'
     }

--- a/src/config.py
+++ b/src/config.py
@@ -27,25 +27,29 @@ SETTINGS = {
         'title' : 'Login',
         'autocomplete' : '> Login',
         'arg' : 'login',
-        'icon' : ICON_ACCOUNT
+        'icon' : ICON_ACCOUNT,
+        'uid' : '0728125C-F4A9-4DB1-A28B-CD0CE0177FF2'
     },
     'LOGOUT' : {
         'title' : 'Logout',
         'autocomplete' : '> Logout',
         'arg' : 'logout',
-        'icon' : ICON_EJECT
+        'icon' : ICON_EJECT,
+        'uid' : '529E8958-C154-48D3-8F66-650215C38249'
     },
     'CLEAR_CACHE' : {
         'title' : 'Clear cache',
         'autocomplete' : '> Clear cache',
         'arg' : 'clear',
-        'icon' : ICON_SYNC
+        'icon' : ICON_SYNC,
+        'uid' : '83F6318C-5BAB-4CA5-BCC0-E9CA38E36C5F'
     },
     'SET_CACHE' : {
         'title' : 'Set cache length %s',
         'autocomplete' : '> Set cache length ',
         'arg' : 'set%s',
-        'icon' : ICON_CLOCK
+        'icon' : ICON_CLOCK,
+        'uid' : '7C76815E-DEA3-4806-A434-1569CBADF205'
     }
 }
 
@@ -54,25 +58,29 @@ CREATE_SETTINGS = {
         'title' : 'New Document',
         'autocomplete' : '> New Document',
         'arg' : 'create_doc',
-        'icon' : './icons/doc.png'
+        'icon' : './icons/doc.png',
+        'uid' : '6EA9C89F-E56A-4DD5-AF21-870869D441E6'
     },
     'SHEET' : {
         'title' : 'New Spreadsheet',
         'autocomplete' : '> New Spreadsheet',
         'arg' : 'create_sheet',
-        'icon' : './icons/sheet.png'
+        'icon' : './icons/sheet.png',
+        'uid' : 'ACAA585E-C8CE-4D64-AE64-2AD41F6CA9F5'
     },
     'SLIDE' : {
         'title' : 'New Presentation',
         'autocomplete' : '> New Presentation',
         'arg' : 'create_slide',
-        'icon' : './icons/slide.png'
+        'icon' : './icons/slide.png',
+        'uid' : 'EB4B6437-13DB-4E65-9F7D-5BE060E37649'
     },
     'FORM' : {
         'title' : 'New Form',
         'autocomplete' : '> New Form',
         'arg' : 'create_form',
-        'icon' : './icons/form.png'
+        'icon' : './icons/form.png',
+        'uid' : '3D2966E3-0639-411D-8334-E1926B8626CF'
     }
 }
 

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,7 @@ from workflow import ICON_ACCOUNT, ICON_EJECT, ICON_WARNING, ICON_SYNC, ICON_CLO
 CLIENT_ID = '978117856621-tvpnqtr02b8u0bgnh75sqb1loq1f5527.apps.googleusercontent.com'
 CLIENT_SECRET = 'rty2NIATZfWFWSDX-XPs2usX'
 SCOPE = 'https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.file'
-FILTER = urllib.quote("mimeType='application/vnd.google-apps.document' or mimeType='application/vnd.google-apps.spreadsheet' or mimeType='application/vnd.google-apps.presentation' or mimeType='application/vnd.google-apps.form' or mimeType='application/pdf'")
+FILTER = urllib.quote("mimeType='application/vnd.google-apps.document' or mimeType='application/vnd.google-apps.spreadsheet' or mimeType='application/vnd.google-apps.presentation' or mimeType='application/vnd.google-apps.form' or mimeType='application/pdf' or mimeType='application/vnd.google-apps.folder'")
 REDIRECT_URI = 'http://127.0.0.1:1337'
 
 AUTH_URL = 'https://accounts.google.com/o/oauth2/auth?scope=%(scope)s&redirect_uri=%(redirect_uri)s&response_type=code&client_id=%(client_id)s&access_type=offline&approval_prompt=force' % {'scope' : SCOPE, 'redirect_uri' : REDIRECT_URI, 'client_id' : CLIENT_ID}

--- a/src/drive_api.py
+++ b/src/drive_api.py
@@ -161,13 +161,13 @@ class Drive:
          # if account is already set
         try:
             wf.get_password('drive_access_token')
-            if 'create google doc'.startswith(user_input.lower()):
+            if 'new document'.startswith(user_input.lower()):
                 cls.show_create_setting('DOC')
-            if 'create google sheet'.startswith(user_input.lower()):
+            if 'new spreadsheet'.startswith(user_input.lower()):
                 cls.show_create_setting('SHEET')
-            if 'create google slide'.startswith(user_input.lower()):
+            if 'new presentation'.startswith(user_input.lower()):
                 cls.show_create_setting('SLIDE')
-            if 'create google form'.startswith(user_input.lower()):
+            if 'new form'.startswith(user_input.lower()):
                 cls.show_create_setting('FORM')
         except: pass
 

--- a/src/drive_api.py
+++ b/src/drive_api.py
@@ -148,28 +148,36 @@ class Drive:
             user_input, a string that contains users setting preference
         """
 
-        if 'login'.startswith(user_input.lower()):
-            cls.show_setting('LOGIN')
-        ## add another condition
-        if 'logout'.startswith(user_input.lower()):
-            cls.show_setting('LOGOUT')
-        if 'clear cache'.startswith(user_input.lower()):
-            cls.show_setting('CLEAR_CACHE')
-        if 'set cache length'.startswith(user_input[:16].lower()):
-            cls.show_set_cache_length(user_input[17:])
+        actions = []
+        for label in [ 'LOGIN', 'LOGOUT', 'CLEAR_CACHE' ]:
+            actions.append(SETTINGS[label])
+
+        actions.append({
+            'title':        SETTINGS['SET_CACHE']['title'] % '[seconds]',
+            'autocomplete': SETTINGS['SET_CACHE']['autocomplete'],
+            'arg':          SETTINGS['SET_CACHE']['arg'],
+            'icon':         SETTINGS['SET_CACHE']['icon']
+        })
 
          # if account is already set
         try:
             wf.get_password('drive_access_token')
-            if 'new document'.startswith(user_input.lower()):
-                cls.show_create_setting('DOC')
-            if 'new spreadsheet'.startswith(user_input.lower()):
-                cls.show_create_setting('SHEET')
-            if 'new presentation'.startswith(user_input.lower()):
-                cls.show_create_setting('SLIDE')
-            if 'new form'.startswith(user_input.lower()):
-                cls.show_create_setting('FORM')
+            for label in [ 'DOC', 'SHEET', 'SLIDE', 'FORM' ]:
+                actions.append(CREATE_SETTINGS[label])
         except: pass
+
+        if len(user_input) > 0:
+            actions = wf.filter(query=user_input, items=actions, key=lambda x : x['title'])
+
+        if len(user_input) > 17 and user_input[:17].lower() == 'set cache length ':
+            cls.show_set_cache_length(user_input[17:])
+        else:
+            for action in actions:
+                wf.add_item(title=action['title'],
+                    arg=action['arg'],
+                    icon=action['icon'],
+                    autocomplete=action['autocomplete'],
+                    valid=True)
 
         if len(wf._items) == 0:
             cls.show_error('InvalidOption')
@@ -177,44 +185,18 @@ class Drive:
         wf.send_feedback()
 
     @classmethod
-    def show_setting(cls, setting):
-        """Show settings"""
-
-        wf.add_item(title=SETTINGS[setting]['title'],
-            arg=SETTINGS[setting]['arg'],
-            icon=SETTINGS[setting]['icon'],
-            autocomplete=SETTINGS[setting]['autocomplete'],
-            valid=True)
-
-    @classmethod
-    def show_create_setting(cls, setting):
-        """Show settings"""
-
-        wf.add_item(title=CREATE_SETTINGS[setting]['title'],
-            arg=CREATE_SETTINGS[setting]['arg'],
-            icon=CREATE_SETTINGS[setting]['icon'],
-            autocomplete=CREATE_SETTINGS[setting]['autocomplete'],
-            valid=True)
-
-
-    @classmethod
     def show_set_cache_length(cls, length):
         """Show set cache length setting"""
 
-        if not len(length):
-            wf.add_item(title=SETTINGS['SET_CACHE']['title'] % '[seconds]',
-                autocomplete=SETTINGS['SET_CACHE']['autocomplete'],
-                icon=SETTINGS['SET_CACHE']['icon'])
-        else:
-            try:
-                int(length)
-                wf.add_item(title=SETTINGS['SET_CACHE']['title'] % util.convert_time(length),
-                    arg=SETTINGS['SET_CACHE']['arg'] % length,
-                    icon=SETTINGS['SET_CACHE']['icon'],
-                    valid=True)
-            except:
-                wf.add_item(title='please insert valid cache length',
-                    icon=ICON_CLOCK)
+        try:
+            int(length)
+            wf.add_item(title=SETTINGS['SET_CACHE']['title'] % util.convert_time(length),
+                arg=SETTINGS['SET_CACHE']['arg'] % length,
+                icon=SETTINGS['SET_CACHE']['icon'],
+                valid=True)
+        except:
+            wf.add_item(title='please insert valid cache length',
+                icon=ICON_CLOCK)
 
     @classmethod
     def show_error(cls, error):

--- a/src/drive_api.py
+++ b/src/drive_api.py
@@ -156,7 +156,8 @@ class Drive:
             'title':        SETTINGS['SET_CACHE']['title'] % '[seconds]',
             'autocomplete': SETTINGS['SET_CACHE']['autocomplete'],
             'arg':          SETTINGS['SET_CACHE']['arg'],
-            'icon':         SETTINGS['SET_CACHE']['icon']
+            'icon':         SETTINGS['SET_CACHE']['icon'],
+            'uid':          SETTINGS['SET_CACHE']['uid']
         })
 
          # if account is already set
@@ -177,7 +178,8 @@ class Drive:
                     arg=action['arg'],
                     icon=action['icon'],
                     autocomplete=action['autocomplete'],
-                    valid=True)
+                    valid=True,
+                    uid=action['uid'])
 
         if len(wf._items) == 0:
             cls.show_error('InvalidOption')


### PR DESCRIPTION
This is consistent with Google’s own terminology (the File → New submenu in the various Google document editors) and “New” is also the standard macOS term for creating a new document.

I also used Google’s terminology for the document types, e.g. Google Sheet → Spreadsheet and Google Slide → Presentation.

![image](https://user-images.githubusercontent.com/11901/28019766-5f92b85c-6582-11e7-9976-2c90ddee3904.png)
