### PR TITLE
Normalize query string from NFD to NFC

### DIFF
--- a/src/google-drive.rb
+++ b/src/google-drive.rb
@@ -472,7 +472,7 @@ begin
       STDERR << "Failed to create document.\nServer responded with status #{response.code}\n"
     end
   elsif ARGV[0] == '--filter'
-    filter = ARGV[1].to_s.strip
+    filter = ARGV[1].to_s.strip.unicode_normalize(:nfc)
     name   = filter =~ /\S+\s(.+)/ ? $1 : nil
 
     res = [


### PR DESCRIPTION
Thank you for your great product!

I got one problem using this workflow.
When we search for files on Google Drive, we cannot get the result correctly if the inputted query includes sonant marks. (e.g. "が")

In my opinion, Alfred seems to treat input strings as utf-8-mac(NFD).
We need to normalize input strings for filtering files correctly.

This pull request has one way of difference for normalize string.
If you are good, please merge this p-r and release a new version.

Another way, we can change this workflow's first script filter as shown below.
If you adopt the following change, close this p-r because it is unnecessary.

```diff
- ./google-drive.rb --filter "$1"
+ ./google-drive.rb --filter $(echo "$1" | iconv -f "UTF-8-MAC" -t "UTF-8")
```